### PR TITLE
feat(challenge-05): Replace spec-first with Spec Kit hands-on workflow

### DIFF
--- a/xxx-GitHubCopilotCostOptimization/Coach/Solution-05.md
+++ b/xxx-GitHubCopilotCostOptimization/Coach/Solution-05.md
@@ -1,64 +1,145 @@
-# Challenge 05 - Spec-Driven Development - Coach's Guide 
+# Challenge 05 - Spec-Driven Development with Spec Kit - Coach's Guide
 
 [< Previous Solution](./Solution-04.md) - **[Home](./README.md)** - [Next Solution >](./Solution-06.md)
 
 ## Notes & Guidance
 
-This challenge proves that deterministic controls (tests, types, linters) are token controls. When GitHub Copilot has a spec to code against, it closes the loop in one call instead of three model turns of trial-and-error.
+This challenge introduces students to **GitHub Spec Kit**, a tool that enables spec-driven development with GitHub Copilot. The core insight: when you give Copilot structured context (specs), it reduces token usage and improves output quality.
 
 ### Key Concepts to Explain
 
-**The Feedback Loop Hierarchy (Cost & Latency):**
+**Spec Kit Workflow:**
 
-1. **Type errors:** Instant feedback, zero credits
-2. **Linter violations:** Seconds, zero credits  
-3. **Unit tests:** Seconds, zero credits
-4. **Agent trial-and-error:** Minutes, high credit cost
-
-**Spec-First Approach:**
-- Write failing tests before implementation (TDD)
-- Define types/interfaces that constrain the solution space
-- Establish clear acceptance criteria in the prompt
-- Let the agent code against the spec
+1. **Constitution:** Project-wide rules and constraints (architecture, standards, patterns)
+2. **Spec:** What to build (requirements, acceptance criteria, user stories)
+3. **Plan:** How to build it (architecture, stack, structure)
+4. **Tasks:** Actionable work items (small, ordered, executable)
+5. **Implement:** Execute tasks with Copilot
 
 **Why This Reduces Cost:**
-- Tests catch errors deterministically instead of agent discovering through iteration
-- Type checkers provide instant feedback vs. agent debugging
-- Clear acceptance criteria prevent "did I meet the requirements?" prompting
-- The research → plan → implement loop prevents expensive backtracking
+
+- Spec becomes persistent context — no need to repeat in every prompt
+- Constitution provides guardrails that apply automatically
+- Structured workflow prevents expensive backtracking
+- Small tasks produce more predictable outputs than large prompts
+- Clarification step catches ambiguity before implementation
 
 ### Expected Time
 
-60 minutes:
-- 25 minutes: Implement feature trial-and-error style (Part A)
-- 25 minutes: Implement same feature spec-first (Part B)
-- 10 minutes: Compare and document findings
+45-60 minutes:
+- 10 minutes: Installation and setup
+- 10 minutes: Constitution and spec creation
+- 10 minutes: Plan and task generation
+- 15 minutes: Implementation with Copilot
+- 10 minutes: Reflection and discussion
+
+### Setup Troubleshooting
+
+**uv Not Installed:**
+
+Students need the `uv` package manager. Install with:
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+See: [Install uv](https://github.com/github/spec-kit/blob/main/docs/install/uv.md)
+
+**Specify CLI Installation:**
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z
+```
+
+Replace `vX.Y.Z` with the latest tag from [Releases](https://github.com/github/spec-kit/releases).
+
+**Alternative Installation (pipx):**
+
+If students prefer pipx:
+```bash
+pipx install git+https://github.com/github/spec-kit.git@vX.Y.Z
+```
+
+**Spec Kit Commands Not Appearing in Copilot Chat:**
+
+1. Verify `.github/prompts/` folder exists with Spec Kit files
+2. Reload VS Code window (Ctrl+Shift+P → "Developer: Reload Window")
+3. Ensure Copilot Chat extension is up to date
+
+**Integration Issues:**
+
+If `--integration copilot` fails, try initializing without integration first:
+```bash
+uvx --from git+https://github.com/github/spec-kit.git specify init my-project
+```
+Then manually copy prompt files to `.github/prompts/`.
 
 ### Success Criteria Validation
 
-Students should demonstrate at least 30% credit reduction using spec-first vs. trial-and-error for the same feature complexity.
+Students should be able to demonstrate:
+
+1. **Setup Complete:** `.specify/` and `.github/prompts/` folders exist
+2. **Constitution Created:** `constitution.md` with project rules
+3. **Spec Generated:** `spec.md` with requirements and acceptance criteria
+4. **Plan Produced:** Architecture and structure decisions documented
+5. **Tasks Listed:** Ordered list of small, actionable items
+6. **Implementation Started:** At least one task executed with Copilot
 
 ### Common Blockers
 
-**Students Don't Know How to Write Specs:**
+**Students Skip Steps:**
 
-Guide them:
-1. Start with types/interfaces (what shape is the solution?)
-2. Write failing tests (what behavior must exist?)
-3. Document acceptance criteria (when am I done?)
+Emphasize the workflow is sequential by design. Each step builds on the previous. Skipping to `/speckit.implement` without a spec produces the same results as ad-hoc prompting.
 
-**Students Skip Research/Plan Phases:**
+**Vague Constitution:**
 
-Explain: The agent can help write your spec! Ask "what tests should I write for feature X?" before asking "implement feature X."
+Guide them to be specific. Bad: "Good code." Good: "Node.js with TypeScript, Express framework, repository pattern, input validation with Joi."
+
+**Spec Too Large:**
+
+If the spec covers too much, `/speckit.plan` and `/speckit.tasks` become unwieldy. Encourage smaller, focused specs for individual features.
+
+**Students Want to Edit Generated Files:**
+
+This is fine! The generated specs/plans are starting points. Encourage editing for accuracy before proceeding.
 
 ### Hints to Share
 
-- "Write the test first" is both good TDD and good token economics
-- Let the agent help write your tests if you provide requirements
-- Type errors are free feedback—leverage them before prompting for fixes
-- The most expensive code is code you have to regenerate after discovering the approach was wrong
-- Research → plan → implement is cheaper than implement → discover wrong → regenerate → recover
+- Use `/speckit.clarify` whenever you feel the spec is ambiguous — it's designed to ask the right questions
+- The constitution applies to everything — write it once, benefit everywhere
+- Review the plan before generating tasks — it's easier to fix architecture issues at the plan stage
+- Tasks should be small enough to complete in a single Copilot interaction
+- You can re-run any command to regenerate — the workflow is iterative
+
+### Reflection Discussion Points
+
+After completion, discuss with students:
+
+1. **What changed?** They didn't need to repeat context in every prompt
+2. **What was NOT repeated?** Requirements, architecture decisions, coding standards
+3. **Predictability:** Outputs should be more consistent when following the spec
+4. **Token impact:** Fewer retries, less context repetition = lower token usage
 
 ### Key Insight for Students
 
-The single most leveraged answer to "how do I make my team more efficient with GitHub Copilot" is: give them fast deterministic feedback loops. Tests, types, and linters close loops in zero credits instead of expensive model turns.
+> **Spec becomes your context. Not the chat.**
+
+Traditional prompting requires repeating context every time. With Spec Kit, the spec IS the context that Copilot references. This is both better engineering and better token economics.
+
+### Demo Script (If Students Struggle)
+
+1. Initialize project: Show the generated folder structure
+2. Run `/speckit.constitution` and show resulting file
+3. Run `/speckit.specify` with a simple requirement
+4. Show how `/speckit.plan` produces architecture from the spec
+5. Run `/speckit.tasks` and show the task breakdown
+6. Execute one task with `/speckit.implement`
+
+### Connection to Other Challenges
+
+- **Challenge 04 (Prompt Architecture):** Spec Kit is a formalized version of structured prompting
+- **Challenge 06 (Token Golf):** Spec Kit naturally reduces tokens by eliminating context repetition
+- **Challenge 07 (Infrastructure):** Constitution can encode infrastructure standards

--- a/xxx-GitHubCopilotCostOptimization/Coach/Solution-05.md
+++ b/xxx-GitHubCopilotCostOptimization/Coach/Solution-05.md
@@ -4,9 +4,26 @@
 
 ## Notes & Guidance
 
-This challenge introduces students to **GitHub Spec Kit**, a tool that enables spec-driven development with GitHub Copilot. The core insight: when you give Copilot structured context (specs), it reduces token usage and improves output quality.
+This challenge introduces students to **spec-driven development** by having them build the **same application twice**: first with ad-hoc prompting, then with **GitHub Spec Kit**. The hands-on comparison makes the benefits tangible.
+
+> **Note:** Spec Kit installation prerequisites are covered in Challenge 0. If students haven't completed setup, direct them there first.
 
 ### Key Concepts to Explain
+
+**Why Two Applications?**
+
+Building the same thing twice demonstrates:
+- How much context repetition happens with ad-hoc prompting
+- How structured specs reduce cognitive load and token usage
+- The difference in output consistency
+
+**Spec Kit is One Approach:**
+
+Emphasize that Spec Kit is **one of many** ways to do spec-driven development. The principle — structured context produces better results — applies regardless of tooling. Other approaches include:
+- Custom instruction files (.github/copilot-instructions.md)
+- Manual spec documents referenced in prompts
+- Project constitution patterns
+- Prompt template systems
 
 **Spec Kit Workflow:**
 
@@ -26,42 +43,12 @@ This challenge introduces students to **GitHub Spec Kit**, a tool that enables s
 
 ### Expected Time
 
-45-60 minutes:
-- 10 minutes: Installation and setup
-- 10 minutes: Constitution and spec creation
-- 10 minutes: Plan and task generation
-- 15 minutes: Implementation with Copilot
-- 10 minutes: Reflection and discussion
+60-90 minutes:
+- 20-30 minutes: Part 1 — Build with ad-hoc prompting
+- 30-40 minutes: Part 2 — Build with Spec Kit workflow
+- 10-20 minutes: Part 3 — Compare results and discussion
 
-### Setup Troubleshooting
-
-**uv Not Installed:**
-
-Students need the `uv` package manager. Install with:
-```bash
-# macOS/Linux
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Windows (PowerShell)
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-See: [Install uv](https://github.com/github/spec-kit/blob/main/docs/install/uv.md)
-
-**Specify CLI Installation:**
-
-```bash
-uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z
-```
-
-Replace `vX.Y.Z` with the latest tag from [Releases](https://github.com/github/spec-kit/releases).
-
-**Alternative Installation (pipx):**
-
-If students prefer pipx:
-```bash
-pipx install git+https://github.com/github/spec-kit.git@vX.Y.Z
-```
+### Troubleshooting
 
 **Spec Kit Commands Not Appearing in Copilot Chat:**
 
@@ -81,12 +68,23 @@ Then manually copy prompt files to `.github/prompts/`.
 
 Students should be able to demonstrate:
 
+**Part 1 — Ad-Hoc Approach:**
+1. Created task-api-adhoc project
+2. Built the API using conversational prompts
+3. Documented observations (context repetition, inconsistencies)
+
+**Part 2 — Spec Kit Approach:**
 1. **Setup Complete:** `.specify/` and `.github/prompts/` folders exist
 2. **Constitution Created:** `constitution.md` with project rules
 3. **Spec Generated:** `spec.md` with requirements and acceptance criteria
 4. **Plan Produced:** Architecture and structure decisions documented
 5. **Tasks Listed:** Ordered list of small, actionable items
 6. **Implementation Started:** At least one task executed with Copilot
+
+**Part 3 — Comparison:**
+1. Completed the comparison table
+2. Can articulate differences between approaches
+3. Understands why structured specs reduce token usage
 
 ### Common Blockers
 
@@ -118,16 +116,27 @@ This is fine! The generated specs/plans are starting points. Encourage editing f
 
 After completion, discuss with students:
 
-1. **What changed?** They didn't need to repeat context in every prompt
-2. **What was NOT repeated?** Requirements, architecture decisions, coding standards
-3. **Predictability:** Outputs should be more consistent when following the spec
-4. **Token impact:** Fewer retries, less context repetition = lower token usage
+1. **Experience Difference:** How did Part 1 feel compared to Part 2?
+2. **Context Repetition:** How many times did they repeat requirements in each approach?
+3. **Consistency:** Was the Spec Kit output more predictable?
+4. **Token Impact:** Fewer retries, less context repetition = lower token usage
+5. **Other Approaches:** What other methods could achieve similar structured benefits?
 
 ### Key Insight for Students
 
 > **Spec becomes your context. Not the chat.**
 
 Traditional prompting requires repeating context every time. With Spec Kit, the spec IS the context that Copilot references. This is both better engineering and better token economics.
+
+### Coaching Part 1 (Ad-Hoc)
+
+Let students experience the frustration! Don't intervene too quickly. Common observations:
+- They had to repeat "use Node.js" multiple times
+- Copilot "forgot" earlier requirements
+- Code style was inconsistent between prompts
+- They felt like they were re-explaining constantly
+
+This pain is what makes Part 2 powerful.
 
 ### Demo Script (If Students Struggle)
 

--- a/xxx-GitHubCopilotCostOptimization/Coach/Solution-05.md
+++ b/xxx-GitHubCopilotCostOptimization/Coach/Solution-05.md
@@ -4,9 +4,17 @@
 
 ## Notes & Guidance
 
-This challenge introduces students to **spec-driven development** by having them build the **same application twice**: first with ad-hoc prompting, then with **GitHub Spec Kit**. The hands-on comparison makes the benefits tangible.
+This challenge introduces students to **spec-driven development** by having them build the **same simple application twice**: first with ad-hoc prompting, then with **GitHub Spec Kit**. The hands-on comparison makes the benefits tangible.
 
 > **Note:** Spec Kit installation prerequisites are covered in Challenge 0. If students haven't completed setup, direct them there first.
+
+### The Application
+
+Students build a **simple notes app** with only 2 requirements:
+1. CRUD operations for notes
+2. Each note has a title (required) and content
+
+This is intentionally simple — the goal is to compare approaches, not build something complex.
 
 ### Key Concepts to Explain
 
@@ -16,6 +24,13 @@ Building the same thing twice demonstrates:
 - How much context repetition happens with ad-hoc prompting
 - How structured specs reduce cognitive load and token usage
 - The difference in output consistency
+
+**Part 1 is Intentionally Unguided:**
+
+Students don't get example prompts — they figure it out themselves. This:
+- Creates authentic frustration with ad-hoc prompting
+- Makes the Spec Kit workflow feel like a relief
+- Produces genuine observations for comparison
 
 **Spec Kit is One Approach:**
 
@@ -43,10 +58,10 @@ Emphasize that Spec Kit is **one of many** ways to do spec-driven development. T
 
 ### Expected Time
 
-60-90 minutes:
-- 20-30 minutes: Part 1 — Build with ad-hoc prompting
-- 30-40 minutes: Part 2 — Build with Spec Kit workflow
-- 10-20 minutes: Part 3 — Compare results and discussion
+45-75 minutes:
+- 15-20 minutes: Part 1 — Build with ad-hoc prompting
+- 20-30 minutes: Part 2 — Build with Spec Kit workflow
+- 10-15 minutes: Part 3 — Compare results and discussion
 
 ### Troubleshooting
 

--- a/xxx-GitHubCopilotCostOptimization/Student/Challenge-05.md
+++ b/xxx-GitHubCopilotCostOptimization/Student/Challenge-05.md
@@ -1,63 +1,243 @@
-# Challenge 05 - Spec-Driven Development
+# Challenge 05 - Spec-Driven Development with Spec Kit
 
 [< Previous Challenge](./Challenge-04.md) - **[Home](../README.md)** - [Next Challenge >](./Challenge-06.md)
 
 ## Introduction
 
-Deterministic controls—tests, linters, type checks, and security scans—are token controls. When GitHub Copilot has a spec to code against and a fast feedback loop to verify correctness, it closes the loop in one tool call instead of three model turns of trial-and-error. Every time the agent "gambles" and discovers a mistake through iteration, you pay for discovery and recovery.
+In this challenge, you will use **GitHub Spec Kit** to implement a **Spec-Driven Development workflow** with GitHub Copilot.
 
-In this challenge, you'll demonstrate that spec-first development isn't just good engineering—it's cost optimization.
+Instead of writing large prompts, you will:
+
+- Define a **constitution (rules)**
+- Create a **spec (what to build)**
+- Generate a **plan (how to build)**
+- Break it into **tasks**
+- Execute implementation
+
+**Goal:** Reduce token usage and improve output quality by using structured specs instead of ad-hoc prompts.
+
+> **Key Concept:** Spec becomes your context. Not the chat.
+
+## Prerequisites
+
+Make sure you have:
+
+- VS Code installed
+- GitHub Copilot + Copilot Chat extension
+- Git installed
+- Python 3.11+ installed
+- Internet access (for installation)
 
 ## Description
 
-You'll implement the same feature twice: once with no spec (trial-and-error), and once with spec-first (deterministic feedback). Compare credit spend and output correctness between the two approaches.
+### Setup
 
-### Trial-and-Error Development
+#### Step 1 — Install Specify CLI
 
-Implement a moderately complex feature using only a vague prompt. Provide GitHub Copilot with a high-level goal without tests, types, interfaces, or acceptance criteria. Let the agent explore, make mistakes, and iterate naturally.
+Requires **[uv](https://docs.astral.sh/uv/)** ([install uv](https://github.com/github/spec-kit/blob/main/docs/install/uv.md)). Replace `vX.Y.Z` with the latest tag from [Releases](https://github.com/github/spec-kit/releases):
 
-Observe and record: retry loops, total credits consumed, discovery time, recovery effort, and final code quality.
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z
+```
 
-### Spec-First Development
+See the [Installation Guide](https://github.com/github/spec-kit/blob/main/docs/installation.md) for alternative methods, verification, upgrade, and troubleshooting.
 
-Implement the same feature using spec-first approach. Before prompting GitHub Copilot, establish your specification: type definitions or interfaces, failing test cases (TDD style), clear acceptance criteria, and enabled linters/type checkers.
+#### Step 2 — Initialize a Project
 
-Then prompt GitHub Copilot with references to your spec and tests, instructing it to implement the feature to make tests pass.
+```bash
+specify init my-project --integration copilot
+cd my-project
+```
 
-Observe and record: iterations needed, total credits consumed, whether the agent closed the loop quickly, and final code quality.
+#### Step 3 — Open in VS Code
+
+```bash
+code .
+```
+
+> **Tip:** To check for updates or upgrade the CLI later, use:
+> ```bash
+> specify self check      # Check if newer release is available
+> specify self upgrade    # Upgrade to latest stable release
+> ```
+
+#### Step 4 — Verify Spec Kit is Ready
+
+In the project folder, you should see:
+
+- `.specify/`
+- `.github/prompts/`
+- Markdown files
+
+This confirms Spec Kit initialized the project successfully.
+
+#### Step 5 — Open Copilot Chat and Verify Commands
+
+1. Open Copilot Chat in VS Code
+2. Click in the chat input box
+3. Type: `/`
+
+You should see these commands available:
+
+- `/speckit.constitution`
+- `/speckit.specify`
+- `/speckit.plan`
+- `/speckit.tasks`
+- `/speckit.implement`
+
+If these appear, Spec Kit is working correctly.
+
+### Scenario
+
+You will build:
+
+> **A REST API for a task management system**
+
+Features:
+- Authentication (JWT)
+- CRUD operations for tasks
+- Task filtering
+- Basic validation
+
+### Workflow Instructions
+
+#### Step 1 — Define Constitution
+
+In Copilot Chat, run:
+
+```
+/speckit.constitution
+```
+
+Then describe your rules:
+
+```
+Node.js project with clean architecture, strong validation, and performance focus.
+All endpoints must follow REST standards.
+```
+
+This creates the `constitution.md` file containing your system rules.
+
+#### Step 2 — Create Spec
+
+Run:
+
+```
+/speckit.specify
+```
+
+Example input:
+
+```
+Build a task management API with authentication, CRUD operations, and filtering.
+Focus on user experience and correctness.
+```
+
+This creates a `spec.md` file with:
+- Requirements
+- Acceptance criteria
+- User stories
+
+#### Step 3 — (Optional) Clarify
+
+Run:
+
+```
+/speckit.clarify
+```
+
+Spec Kit will ask clarifying questions to improve your spec. This:
+- Reduces ambiguity
+- Reduces rework later
+
+#### Step 4 — Generate Plan
+
+Run:
+
+```
+/speckit.plan
+```
+
+This generates:
+- Architecture decisions
+- Technology stack
+- Project structure
+
+#### Step 5 — Generate Tasks
+
+Run:
+
+```
+/speckit.tasks
+```
+
+This creates:
+- List of small, actionable tasks
+- Execution order
+
+#### Step 6 — Implement
+
+Run:
+
+```
+/speckit.implement
+```
+
+Now Copilot will:
+- Execute tasks sequentially
+- Generate code incrementally
+
+## Rules
+
+- Always follow the Spec Kit workflow order
+- Do NOT skip steps
+- Review each output before continuing
+- Make minimal edits — avoid rewriting everything
 
 ## Success Criteria
 
 To complete this challenge successfully, you should be able to:
 
-- Demonstrate completion of a feature using both trial-and-error and spec-first approaches
-- Show measured credit costs for both approaches with the same feature complexity
-- Verify that spec-first approach required fewer retry loops than trial-and-error
-- Demonstrate significant credit reduction using spec-first vs. trial-and-error
-- Show that spec-first output met acceptance criteria with fewer iterations
-- Explain how deterministic controls (tests, types, linters) act as token controls
-- Document your feedback loop hierarchy ranking mechanisms by speed and cost
+- Successfully install and initialize Spec Kit with Copilot integration
+- Create a constitution that defines project rules and standards
+- Generate a spec from your requirements description
+- Produce a structured plan from the spec
+- Break the plan into executable tasks
+- Implement features using the spec-driven workflow
+- Demonstrate reduced token usage compared to ad-hoc prompting
+- Show improved output consistency and predictability
 
 ## Learning Resources
 
-- [Test-Driven Development Fundamentals](https://martinfowler.com/bliki/TestDrivenDevelopment.html)
-- [Type Systems as Documentation](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html)
-- [The Cost of Rework in Software Development](https://martinfowler.com/articles/is-quality-worth-cost.html)
-- [GitHub Copilot and Test-Driven Development](https://docs.github.com/en/copilot)
+- [GitHub Spec Kit Repository](https://github.com/github/spec-kit)
+- [Spec Kit Installation Guide](https://deepwiki.com/github/spec-kit/2.1-installation)
+- [Spec-Driven Development with GitHub Spec Kit](https://medium.com/@vamshi.rapolu/spec-driven-development-with-github-spec-kit-copilot-in-vs-code-new-existing-projects-2531d10bd61d)
+- [Spec Kit Commands Reference](https://easyguides.net/guides/spec-kit/commands)
+- [Plan and Tasks Commands Tutorial](https://codestandup.com/posts/2025/github-spec-kit-tutorial-plan-tasks-commands/)
 
 ## Tips
 
-- "Write the test first" is both good TDD and good token economics
-- Type errors are free feedback—leverage them before asking the agent
-- Linters catch mistakes at zero credit cost—run them before prompting for fixes
-- The agent can write your tests if you provide the spec, then implement against those tests
-- Research → plan → implement is cheaper than implement → discover mistake → regenerate → recover
-- The single most leveraged answer to "how do I make devs more efficient with Copilot" is: give them fast deterministic feedback loops
+- Spec becomes your persistent context — no need to repeat requirements in every prompt
+- The constitution acts as guardrails that apply to all generated code
+- Use `/speckit.clarify` when requirements feel ambiguous
+- Each step builds on the previous — the workflow is designed to be sequential
+- Review generated specs and plans before proceeding to catch issues early
+- Small, focused specs produce better results than large, vague ones
+
+## Reflection Questions
+
+After completing this challenge, answer:
+
+1. What changed compared to normal prompting?
+2. What did you NOT have to repeat in your prompts?
+3. Did the outputs become more predictable?
+4. How would this workflow impact token usage in real scenarios?
 
 ## Advanced Challenges
 
 Too comfortable? Try these:
 
-- Implement pre-commit hooks that run tests/linters and provide feedback before GitHub Copilot generates fixes
-- Create a CI pipeline that provides GitHub Copilot with test results as context for fixing failures
-- Measure the credit cost difference between "fix this bug" (vague) vs. "fix this bug: test X fails with error Y" (specific)
+- Apply Spec Kit to an existing project instead of a new one
+- Create multiple specs for different features and observe how they interact
+- Measure credit consumption between spec-driven and traditional prompting for the same feature
+- Customize the constitution for different project types (frontend, backend, full-stack)

--- a/xxx-GitHubCopilotCostOptimization/Student/Challenge-05.md
+++ b/xxx-GitHubCopilotCostOptimization/Student/Challenge-05.md
@@ -4,9 +4,11 @@
 
 ## Introduction
 
-In this challenge, you will use **GitHub Spec Kit** to implement a **Spec-Driven Development workflow** with GitHub Copilot.
+In this challenge, you will experience the difference between **ad-hoc prompting** and **spec-driven development** by building the same application twice — first without structure, then using **GitHub Spec Kit**.
 
-Instead of writing large prompts, you will:
+Spec Kit is one of several ways to implement spec-driven development with GitHub Copilot. The core principle applies regardless of tooling: **structured context produces better results than conversational prompts**.
+
+With Spec Kit, you will:
 
 - Define a **constitution (rules)**
 - Create a **spec (what to build)**
@@ -14,80 +16,20 @@ Instead of writing large prompts, you will:
 - Break it into **tasks**
 - Execute implementation
 
-**Goal:** Reduce token usage and improve output quality by using structured specs instead of ad-hoc prompts.
+**Goal:** Experience firsthand how structured specs reduce token usage and improve output quality compared to ad-hoc prompting.
 
 > **Key Concept:** Spec becomes your context. Not the chat.
 
-## Prerequisites
-
-Make sure you have:
-
-- VS Code installed
-- GitHub Copilot + Copilot Chat extension
-- Git installed
-- Python 3.11+ installed
-- Internet access (for installation)
-
 ## Description
 
-### Setup
+In this challenge, you will build **the same application twice**:
 
-#### Step 1 — Install Specify CLI
+1. **Part 1:** Build with ad-hoc prompting (no structure)
+2. **Part 2:** Build with Spec Kit workflow
 
-Requires **[uv](https://docs.astral.sh/uv/)** ([install uv](https://github.com/github/spec-kit/blob/main/docs/install/uv.md)). Replace `vX.Y.Z` with the latest tag from [Releases](https://github.com/github/spec-kit/releases):
+Then compare the results.
 
-```bash
-uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z
-```
-
-See the [Installation Guide](https://github.com/github/spec-kit/blob/main/docs/installation.md) for alternative methods, verification, upgrade, and troubleshooting.
-
-#### Step 2 — Initialize a Project
-
-```bash
-specify init my-project --integration copilot
-cd my-project
-```
-
-#### Step 3 — Open in VS Code
-
-```bash
-code .
-```
-
-> **Tip:** To check for updates or upgrade the CLI later, use:
-> ```bash
-> specify self check      # Check if newer release is available
-> specify self upgrade    # Upgrade to latest stable release
-> ```
-
-#### Step 4 — Verify Spec Kit is Ready
-
-In the project folder, you should see:
-
-- `.specify/`
-- `.github/prompts/`
-- Markdown files
-
-This confirms Spec Kit initialized the project successfully.
-
-#### Step 5 — Open Copilot Chat and Verify Commands
-
-1. Open Copilot Chat in VS Code
-2. Click in the chat input box
-3. Type: `/`
-
-You should see these commands available:
-
-- `/speckit.constitution`
-- `/speckit.specify`
-- `/speckit.plan`
-- `/speckit.tasks`
-- `/speckit.implement`
-
-If these appear, Spec Kit is working correctly.
-
-### Scenario
+### The Application
 
 You will build:
 
@@ -99,9 +41,76 @@ Features:
 - Task filtering
 - Basic validation
 
-### Workflow Instructions
+---
 
-#### Step 1 — Define Constitution
+## Part 1 — Build with Ad-Hoc Prompting
+
+First, build the application using traditional prompting.
+
+### Step 1 — Create a New Project Folder
+
+```bash
+mkdir task-api-adhoc
+cd task-api-adhoc
+code .
+```
+
+### Step 2 — Build Using Conversational Prompts
+
+Open Copilot Chat and use prompts like:
+
+```
+Create a REST API for task management with authentication, CRUD operations, 
+task filtering, and validation. Use Node.js with clean architecture.
+```
+
+Continue prompting to:
+- Add endpoints
+- Implement authentication
+- Add validation logic
+- Create filtering
+
+### Step 3 — Track Your Experience
+
+As you work, note:
+- How many times you had to repeat context
+- How many times Copilot "forgot" requirements
+- Total number of prompts needed
+- Any inconsistencies in generated code
+
+### Step 4 — Save Your Results
+
+Keep this project. You'll compare it later.
+
+---
+
+## Part 2 — Build with Spec Kit
+
+Now build the **same application** using the Spec Kit workflow.
+
+### Step 1 — Initialize a New Spec Kit Project
+
+```bash
+specify init task-api-speckit --integration copilot
+cd task-api-speckit
+code .
+```
+
+### Step 2 — Verify Spec Kit is Ready
+
+In the project folder, you should see:
+- `.specify/`
+- `.github/prompts/`
+- Markdown files
+
+In Copilot Chat, type `/` — you should see:
+- `/speckit.constitution`
+- `/speckit.specify`
+- `/speckit.plan`
+- `/speckit.tasks`
+- `/speckit.implement`
+
+### Step 3 — Define Constitution
 
 In Copilot Chat, run:
 
@@ -118,7 +127,7 @@ All endpoints must follow REST standards.
 
 This creates the `constitution.md` file containing your system rules.
 
-#### Step 2 — Create Spec
+### Step 4 — Create Spec
 
 Run:
 
@@ -138,7 +147,7 @@ This creates a `spec.md` file with:
 - Acceptance criteria
 - User stories
 
-#### Step 3 — (Optional) Clarify
+### Step 5 — (Optional) Clarify
 
 Run:
 
@@ -150,7 +159,7 @@ Spec Kit will ask clarifying questions to improve your spec. This:
 - Reduces ambiguity
 - Reduces rework later
 
-#### Step 4 — Generate Plan
+### Step 6 — Generate Plan
 
 Run:
 
@@ -163,7 +172,7 @@ This generates:
 - Technology stack
 - Project structure
 
-#### Step 5 — Generate Tasks
+### Step 7 — Generate Tasks
 
 Run:
 
@@ -175,7 +184,7 @@ This creates:
 - List of small, actionable tasks
 - Execution order
 
-#### Step 6 — Implement
+### Step 8 — Implement
 
 Run:
 
@@ -187,37 +196,63 @@ Now Copilot will:
 - Execute tasks sequentially
 - Generate code incrementally
 
+---
+
+## Part 3 — Compare Results
+
+Now compare both implementations.
+
+### Questions to Answer
+
+| Aspect | Ad-Hoc Approach | Spec Kit Approach |
+|--------|-----------------|-------------------|
+| Total prompts needed | ? | ? |
+| Times you repeated context | ? | ? |
+| Code consistency | ? | ? |
+| Time to complete | ? | ? |
+| Quality of output | ? | ? |
+
+### What to Look For
+
+- **Context retention:** Did Copilot remember requirements?
+- **Consistency:** Did the code follow the same patterns throughout?
+- **Completeness:** Were all requirements addressed?
+- **Token efficiency:** How much did you have to type?
+
 ## Rules
 
-- Always follow the Spec Kit workflow order
-- Do NOT skip steps
+- Complete Part 1 before starting Part 2
+- Do NOT skip steps in the Spec Kit workflow
 - Review each output before continuing
 - Make minimal edits — avoid rewriting everything
+- Document your observations for comparison
 
 ## Success Criteria
 
 To complete this challenge successfully, you should be able to:
 
-- Successfully install and initialize Spec Kit with Copilot integration
+- Build the task management API using ad-hoc prompting
+- Build the same API using Spec Kit workflow
 - Create a constitution that defines project rules and standards
 - Generate a spec from your requirements description
 - Produce a structured plan from the spec
 - Break the plan into executable tasks
-- Implement features using the spec-driven workflow
-- Demonstrate reduced token usage compared to ad-hoc prompting
+- Compare both approaches and articulate the differences
+- Demonstrate reduced token usage with spec-driven development
 - Show improved output consistency and predictability
 
 ## Learning Resources
 
 - [GitHub Spec Kit Repository](https://github.com/github/spec-kit)
-- [Spec Kit Installation Guide](https://deepwiki.com/github/spec-kit/2.1-installation)
+- [Spec Kit Installation Guide](https://github.com/github/spec-kit/blob/main/docs/installation.md)
 - [Spec-Driven Development with GitHub Spec Kit](https://medium.com/@vamshi.rapolu/spec-driven-development-with-github-spec-kit-copilot-in-vs-code-new-existing-projects-2531d10bd61d)
 - [Spec Kit Commands Reference](https://easyguides.net/guides/spec-kit/commands)
 - [Plan and Tasks Commands Tutorial](https://codestandup.com/posts/2025/github-spec-kit-tutorial-plan-tasks-commands/)
 
 ## Tips
 
-- Spec becomes your persistent context — no need to repeat requirements in every prompt
+- Part 1 intentionally feels inefficient — that's the point!
+- Spec becomes your persistent context — no need to repeat requirements
 - The constitution acts as guardrails that apply to all generated code
 - Use `/speckit.clarify` when requirements feel ambiguous
 - Each step builds on the previous — the workflow is designed to be sequential
@@ -228,10 +263,11 @@ To complete this challenge successfully, you should be able to:
 
 After completing this challenge, answer:
 
-1. What changed compared to normal prompting?
-2. What did you NOT have to repeat in your prompts?
-3. Did the outputs become more predictable?
-4. How would this workflow impact token usage in real scenarios?
+1. How did Part 1 (ad-hoc) feel compared to Part 2 (Spec Kit)?
+2. How many times did you repeat context in each approach?
+3. Did the outputs become more predictable with Spec Kit?
+4. How would spec-driven development impact token usage and costs in real projects?
+5. What other tools or methods could achieve similar spec-driven benefits?
 
 ## Advanced Challenges
 
@@ -239,5 +275,5 @@ Too comfortable? Try these:
 
 - Apply Spec Kit to an existing project instead of a new one
 - Create multiple specs for different features and observe how they interact
-- Measure credit consumption between spec-driven and traditional prompting for the same feature
+- Measure credit consumption between both approaches for the same feature
 - Customize the constitution for different project types (frontend, backend, full-stack)

--- a/xxx-GitHubCopilotCostOptimization/Student/Challenge-05.md
+++ b/xxx-GitHubCopilotCostOptimization/Student/Challenge-05.md
@@ -33,50 +33,47 @@ Then compare the results.
 
 You will build:
 
-> **A REST API for a task management system**
+> **A simple notes application**
 
-Features:
-- Authentication (JWT)
-- CRUD operations for tasks
-- Task filtering
-- Basic validation
+Requirements:
+1. Create, read, update, and delete notes (CRUD)
+2. Each note must have a title (required) and content
+
+That's it — keep it simple!
 
 ---
 
 ## Part 1 — Build with Ad-Hoc Prompting
 
-First, build the application using traditional prompting.
+First, build the application using traditional conversational prompting with Copilot.
 
 ### Step 1 — Create a New Project Folder
 
 ```bash
-mkdir task-api-adhoc
-cd task-api-adhoc
+mkdir notes-app-adhoc
+cd notes-app-adhoc
 code .
 ```
 
-### Step 2 — Build Using Conversational Prompts
+### Step 2 — Build the Application
 
-Open Copilot Chat and use prompts like:
+Your goal: Create a working notes application that meets the 2 requirements above.
 
-```
-Create a REST API for task management with authentication, CRUD operations, 
-task filtering, and validation. Use Node.js with clean architecture.
-```
+**Rules:**
+- Use only Copilot Chat with ad-hoc prompts
+- No pre-written specs or documentation
+- Just start prompting and see what happens
 
-Continue prompting to:
-- Add endpoints
-- Implement authentication
-- Add validation logic
-- Create filtering
+**Try to complete the application on your own!**
 
 ### Step 3 — Track Your Experience
 
 As you work, note:
-- How many times you had to repeat context
-- How many times Copilot "forgot" requirements
-- Total number of prompts needed
-- Any inconsistencies in generated code
+- How many prompts did you need?
+- How many times did you repeat the same information?
+- Did Copilot "forget" what you asked earlier?
+- Was the generated code consistent in style?
+- How did it feel?
 
 ### Step 4 — Save Your Results
 
@@ -91,8 +88,8 @@ Now build the **same application** using the Spec Kit workflow.
 ### Step 1 — Initialize a New Spec Kit Project
 
 ```bash
-specify init task-api-speckit --integration copilot
-cd task-api-speckit
+specify init notes-app-speckit --integration copilot
+cd notes-app-speckit
 code .
 ```
 
@@ -118,11 +115,10 @@ In Copilot Chat, run:
 /speckit.constitution
 ```
 
-Then describe your rules:
+Then describe your rules. Example:
 
 ```
-Node.js project with clean architecture, strong validation, and performance focus.
-All endpoints must follow REST standards.
+Simple local application. Clean code with clear separation of concerns.
 ```
 
 This creates the `constitution.md` file containing your system rules.
@@ -135,11 +131,11 @@ Run:
 /speckit.specify
 ```
 
-Example input:
+Describe the same requirements as Part 1:
 
 ```
-Build a task management API with authentication, CRUD operations, and filtering.
-Focus on user experience and correctness.
+A notes application with CRUD operations. 
+Each note has a title (required) and content.
 ```
 
 This creates a `spec.md` file with:


### PR DESCRIPTION
## Summary

This PR updates Challenge 05 to use **GitHub Spec Kit** with a hands-on, practical workflow instead of the previous abstract spec-first vs trial-and-error comparison.

## Changes

### Student Challenge (Challenge-05.md)
- Replaced abstract comparison exercise with hands-on Spec Kit workflow
- Added proper installation steps using `uv tool install`
- Included complete workflow: constitution → spec → clarify → plan → tasks → implement
- Added Task Management API as the practical scenario
- Updated success criteria to match Spec Kit workflow
- Added reflection questions for learning
- Updated learning resources with official Spec Kit documentation

### Coach Guide (Solution-05.md)
- Updated troubleshooting section for `uv` installation (macOS/Linux/Windows)
- Added correct Specify CLI installation command
- Added pipx alternative installation method
- Updated demo script to match new workflow
- Added connection points to other challenges

## Why This Change?

The previous challenge asked students to compare spec-first vs trial-and-error abstractly. This update provides:
- Real, executable commands
- A concrete scenario (Task Management API)
- Step-by-step verification at each stage
- Clear learning outcomes tied to token/cost optimization